### PR TITLE
Phone Verification UI with backend 

### DIFF
--- a/NewDawn/NewDawn.xcodeproj/project.pbxproj
+++ b/NewDawn/NewDawn.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		24C0464021C54F02006EC02E /* PhoneVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */; };
 		24C0464221C54FE5006EC02E /* PhoneAuthenticateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C0464121C54FE5006EC02E /* PhoneAuthenticateViewController.swift */; };
+		24C0464521CD9BB0006EC02E /* UserInfoModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 24C0464321CD9BB0006EC02E /* UserInfoModel.xcdatamodeld */; };
 		24F657FC21B31C1300DB2547 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F657FB21B31C1300DB2547 /* AppDelegate.swift */; };
 		24F657FE21B31C1300DB2547 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F657FD21B31C1300DB2547 /* ViewController.swift */; };
 		24F6580121B31C1300DB2547 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24F657FF21B31C1300DB2547 /* Main.storyboard */; };
@@ -46,6 +47,7 @@
 		178CD26DF50D54E486AB41DD /* Pods-NewDawnTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NewDawnTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NewDawnTests/Pods-NewDawnTests.release.xcconfig"; sourceTree = "<group>"; };
 		24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerifyViewController.swift; sourceTree = "<group>"; };
 		24C0464121C54FE5006EC02E /* PhoneAuthenticateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneAuthenticateViewController.swift; sourceTree = "<group>"; };
+		24C0464421CD9BB0006EC02E /* UserInfoModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserInfoModel.xcdatamodel; sourceTree = "<group>"; };
 		24F657F821B31C1300DB2547 /* NewDawn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NewDawn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		24F657FB21B31C1300DB2547 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		24F657FD21B31C1300DB2547 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 				24F6580421B31C1300DB2547 /* LaunchScreen.storyboard */,
 				24F6580721B31C1300DB2547 /* Info.plist */,
 				24F6582921B325D300DB2547 /* SignInViewController.swift */,
+				24C0464321CD9BB0006EC02E /* UserInfoModel.xcdatamodeld */,
 				24F6582B21B327F200DB2547 /* RegisterUserViewController.swift */,
 				24F6582D21B32C3700DB2547 /* ProfileViewController.swift */,
 				24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */,
@@ -418,6 +421,7 @@
 				24F657FC21B31C1300DB2547 /* AppDelegate.swift in Sources */,
 				24C0464221C54FE5006EC02E /* PhoneAuthenticateViewController.swift in Sources */,
 				24C0464021C54F02006EC02E /* PhoneVerifyViewController.swift in Sources */,
+				24C0464521CD9BB0006EC02E /* UserInfoModel.xcdatamodeld in Sources */,
 				24F6582A21B325D300DB2547 /* SignInViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -696,6 +700,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		24C0464321CD9BB0006EC02E /* UserInfoModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				24C0464421CD9BB0006EC02E /* UserInfoModel.xcdatamodel */,
+			);
+			currentVersion = 24C0464421CD9BB0006EC02E /* UserInfoModel.xcdatamodel */;
+			path = UserInfoModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 24F657F021B31C1300DB2547 /* Project object */;
 }

--- a/NewDawn/NewDawn.xcodeproj/project.pbxproj
+++ b/NewDawn/NewDawn.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		24C0464021C54F02006EC02E /* PhoneVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */; };
 		24C0464221C54FE5006EC02E /* PhoneAuthenticateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C0464121C54FE5006EC02E /* PhoneAuthenticateViewController.swift */; };
 		24C0464521CD9BB0006EC02E /* UserInfoModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 24C0464321CD9BB0006EC02E /* UserInfoModel.xcdatamodeld */; };
+		24C0468421CDC84E006EC02E /* ProfileGNBViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C0468321CDC84E006EC02E /* ProfileGNBViewController.swift */; };
 		24F657FC21B31C1300DB2547 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F657FB21B31C1300DB2547 /* AppDelegate.swift */; };
 		24F657FE21B31C1300DB2547 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F657FD21B31C1300DB2547 /* ViewController.swift */; };
 		24F6580121B31C1300DB2547 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24F657FF21B31C1300DB2547 /* Main.storyboard */; };
@@ -48,6 +49,7 @@
 		24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerifyViewController.swift; sourceTree = "<group>"; };
 		24C0464121C54FE5006EC02E /* PhoneAuthenticateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneAuthenticateViewController.swift; sourceTree = "<group>"; };
 		24C0464421CD9BB0006EC02E /* UserInfoModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserInfoModel.xcdatamodel; sourceTree = "<group>"; };
+		24C0468321CDC84E006EC02E /* ProfileGNBViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGNBViewController.swift; sourceTree = "<group>"; };
 		24F657F821B31C1300DB2547 /* NewDawn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NewDawn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		24F657FB21B31C1300DB2547 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		24F657FD21B31C1300DB2547 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				24F6582D21B32C3700DB2547 /* ProfileViewController.swift */,
 				24C0463F21C54F02006EC02E /* PhoneVerifyViewController.swift */,
 				24C0464121C54FE5006EC02E /* PhoneAuthenticateViewController.swift */,
+				24C0468321CDC84E006EC02E /* ProfileGNBViewController.swift */,
 			);
 			path = NewDawn;
 			sourceTree = "<group>";
@@ -420,6 +423,7 @@
 				24F6582E21B32C3700DB2547 /* ProfileViewController.swift in Sources */,
 				24F657FC21B31C1300DB2547 /* AppDelegate.swift in Sources */,
 				24C0464221C54FE5006EC02E /* PhoneAuthenticateViewController.swift in Sources */,
+				24C0468421CDC84E006EC02E /* ProfileGNBViewController.swift in Sources */,
 				24C0464021C54F02006EC02E /* PhoneVerifyViewController.swift in Sources */,
 				24C0464521CD9BB0006EC02E /* UserInfoModel.xcdatamodeld in Sources */,
 				24F6582A21B325D300DB2547 /* SignInViewController.swift in Sources */,

--- a/NewDawn/NewDawn/AppDelegate.swift
+++ b/NewDawn/NewDawn/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 New Dawn. All rights reserved.
 //
 
+import CoreData
 import UIKit
 import SwiftKeychainWrapper
 
@@ -47,6 +48,53 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        // Saves changes in the application's managed object context before the application terminates.
+        self.saveContext()
+    }
+    
+    // MARK: - Core Data stack
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        let container = NSPersistentContainer(name: "Test")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
     }
 
 

--- a/NewDawn/NewDawn/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/NewDawn/NewDawn/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/NewDawn/NewDawn/Base.lproj/Main.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="W2h-ud-Kx5">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -18,11 +18,11 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign In" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GL0-mV-yta">
-                                <rect key="frame" x="147.5" y="154" width="80" height="21"/>
+                                <rect key="frame" x="167" y="154" width="80" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="ABD-hz-C5y"/>
                                 </constraints>
@@ -31,25 +31,25 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Don't have an account?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0m7-co-M3W">
-                                <rect key="frame" x="97" y="546" width="181" height="21"/>
+                                <rect key="frame" x="101" y="615" width="212" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="njC-9e-AMR">
-                                <rect key="frame" x="86" y="190" width="203" height="30"/>
+                                <rect key="frame" x="90" y="190" width="234" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="Gnf-nm-CHx">
-                                <rect key="frame" x="86" y="228" width="203" height="30"/>
+                                <rect key="frame" x="90" y="228" width="234" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jML-so-Df4">
-                                <rect key="frame" x="155" y="276" width="65" height="30"/>
+                                <rect key="frame" x="174.66666666666666" y="276" width="65" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="65" id="YMK-Vl-Fax"/>
                                 </constraints>
@@ -61,7 +61,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tut-yX-EFM">
-                                <rect key="frame" x="105" y="583" width="165" height="30"/>
+                                <rect key="frame" x="109" y="652" width="196" height="30"/>
                                 <color key="backgroundColor" red="0.54935756319999995" green="0.63756916789999996" blue="0.91372549020000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <state key="normal" title="Register new account">
@@ -111,7 +111,7 @@
                         <viewControllerLayoutGuide type="bottom" id="qbu-sU-cNV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="VmK-Hg-VKy">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Register New Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Db3-GP-wH6">
@@ -121,7 +121,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="First Name" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="Xpo-Sl-3ia">
-                                <rect key="frame" x="96" y="178" width="89" height="30"/>
+                                <rect key="frame" x="100" y="178" width="89" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="89" id="wNC-bc-nz6"/>
                                 </constraints>
@@ -154,7 +154,7 @@
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aaQ-Rj-x5h">
-                                <rect key="frame" x="82" y="373" width="94" height="30"/>
+                                <rect key="frame" x="86" y="373" width="94" height="30"/>
                                 <color key="backgroundColor" red="0.91372549020000005" green="0.47128016884731311" blue="0.64401873041224778" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="94" id="yTF-XK-rQh"/>
@@ -166,7 +166,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sLY-Wj-cFR">
-                                <rect key="frame" x="199" y="373" width="94" height="30"/>
+                                <rect key="frame" x="203" y="373" width="125" height="30"/>
                                 <color key="backgroundColor" red="0.68681715629999995" green="0.91372549020000005" blue="0.80714514739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <state key="normal" title="Sign Up"/>
@@ -222,24 +222,24 @@
                         <viewControllerLayoutGuide type="bottom" id="ROg-tl-Wgl"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="idp-tg-ivg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="00b-uW-ty4">
-                                <rect key="frame" x="135.5" y="111" width="104" height="29"/>
+                                <rect key="frame" x="155" y="111" width="104" height="98"/>
                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="23"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yah-9i-UVb">
-                                <rect key="frame" x="299" y="28" width="60" height="30"/>
+                                <rect key="frame" x="334" y="28" width="60" height="30"/>
                                 <state key="normal" title="Sign Out"/>
                                 <connections>
                                     <action selector="signOutButtonTapped:" destination="eeS-71-CHZ" eventType="touchUpInside" id="whp-Zq-cw3"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ImO-pq-Mp9">
-                                <rect key="frame" x="98" y="147" width="179" height="21"/>
+                                <rect key="frame" x="102" y="216" width="210" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="KMf-U1-1eU"/>
                                 </constraints>
@@ -248,7 +248,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lcM-PI-YHJ">
-                                <rect key="frame" x="131" y="223" width="113" height="21"/>
+                                <rect key="frame" x="150.66666666666666" y="292" width="112.99999999999997" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Lv3-cj-SBS"/>
                                 </constraints>
@@ -257,7 +257,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Graduated From" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mM8-rT-6Mm">
-                                <rect key="frame" x="131" y="194" width="113" height="21"/>
+                                <rect key="frame" x="150.66666666666666" y="263" width="112.99999999999997" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="cNS-tp-6q8"/>
                                 </constraints>
@@ -266,7 +266,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xAK-7q-IXA">
-                                <rect key="frame" x="131" y="302" width="113" height="21"/>
+                                <rect key="frame" x="150.66666666666666" y="371" width="112.99999999999997" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="olu-BF-Mlp"/>
                                     <constraint firstAttribute="width" constant="113" id="tcH-hA-9JN"/>
@@ -276,7 +276,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hometown" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MVF-8w-TZJ">
-                                <rect key="frame" x="131" y="273" width="113" height="21"/>
+                                <rect key="frame" x="150.66666666666666" y="342" width="112.99999999999997" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Jg8-wz-M6w"/>
                                 </constraints>
@@ -402,7 +402,7 @@
                         <viewControllerLayoutGuide type="bottom" id="bHC-LO-C6P"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="AZs-lA-0pS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Input Your Phone Number" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4tW-sO-R87">
@@ -463,7 +463,7 @@
                         <viewControllerLayoutGuide type="bottom" id="4qd-s4-Fih"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="pB2-Ko-XuB">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Input Verification Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WEp-mJ-IgN">

--- a/NewDawn/NewDawn/Base.lproj/Main.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/Main.storyboard
@@ -4,7 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
+        <deployment version="4352" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -405,54 +405,81 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Input Your Phone Number" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4tW-sO-R87">
-                                <rect key="frame" x="88" y="195" width="198" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What's your number?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4tW-sO-R87">
+                                <rect key="frame" x="54" y="148" width="306" height="36"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="30"/>
+                                <color key="textColor" red="0.50196078431372548" green="0.50196078431372548" blue="0.50196078431372548" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="r2E-Fq-sN6">
-                                <rect key="frame" x="156" y="230" width="130" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FAX-UP-Jfb">
-                                <rect key="frame" x="106" y="231" width="42" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="+" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cKr-As-CcG">
-                                <rect key="frame" x="88" y="235" width="11" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ds9-Ji-qBy">
-                                <rect key="frame" x="171" y="268" width="32" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Next"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ds9-Ji-qBy">
+                                <rect key="frame" x="70.666666666666686" y="397" width="273" height="41"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="273" id="BRy-N1-I0G"/>
+                                    <constraint firstAttribute="height" constant="41" id="UWQ-Cn-ugy"/>
+                                </constraints>
+                                <state key="normal" title="Continue">
+                                    <color key="titleColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                </state>
                                 <connections>
                                     <action selector="nextButtonTapped:" destination="W2h-ud-Kx5" eventType="touchUpInside" id="RIk-eZ-W8f"/>
                                     <segue destination="6wi-dA-koT" kind="show" identifier="phoneVerify" id="fy0-bA-rjO"/>
                                 </connections>
                             </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Please use your phone number to either create an account or sign back in" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVI-I1-FIZ">
+                                <rect key="frame" x="66.666666666666686" y="204" width="281" height="45"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="281" id="DXY-cq-PWr"/>
+                                    <constraint firstAttribute="height" constant="45" id="wmY-dt-8gC"/>
+                                </constraints>
+                                <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" name="PingFangTC-Semibold" family="PingFang TC" pointSize="13"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="EVo-Ee-8rk">
+                                <rect key="frame" x="69" y="314" width="276" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="Lp0-70-Gvq"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="276" id="b2D-zy-Gmt"/>
+                                </constraints>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IxL-wb-f4W">
+                                <rect key="frame" x="77.666666666666671" y="322" width="19" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="19" id="Gyv-VO-1rc"/>
+                                    <constraint firstAttribute="height" constant="21" id="wbr-me-hSz"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="14"/>
+                                <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="EVo-Ee-8rk" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" id="4C7-t2-BUb"/>
+                            <constraint firstItem="SVI-I1-FIZ" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" id="9E6-Vg-cBA"/>
+                            <constraint firstItem="4tW-sO-R87" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" id="9SN-eX-gJB"/>
+                            <constraint firstItem="Ds9-Ji-qBy" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" id="Ijj-tq-hta"/>
+                            <constraint firstItem="IxL-wb-f4W" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" constant="-120" id="KQd-uJ-Cp6"/>
+                            <constraint firstItem="EVo-Ee-8rk" firstAttribute="top" secondItem="SVI-I1-FIZ" secondAttribute="bottom" constant="65" id="ZQw-S4-kdN"/>
+                            <constraint firstItem="IxL-wb-f4W" firstAttribute="top" secondItem="SVI-I1-FIZ" secondAttribute="bottom" constant="73" id="erf-1z-HK0"/>
+                            <constraint firstItem="Ds9-Ji-qBy" firstAttribute="centerX" secondItem="AZs-lA-0pS" secondAttribute="centerX" id="nmo-Tl-8Zw"/>
+                            <constraint firstItem="4tW-sO-R87" firstAttribute="top" secondItem="cPO-34-C90" secondAttribute="bottom" constant="128" id="rAF-32-gCn"/>
+                            <constraint firstItem="SVI-I1-FIZ" firstAttribute="top" secondItem="4tW-sO-R87" secondAttribute="bottom" constant="20" id="uxw-AU-ihV"/>
+                            <constraint firstItem="Ds9-Ji-qBy" firstAttribute="top" secondItem="EVo-Ee-8rk" secondAttribute="bottom" constant="43" id="w1i-PC-AOa"/>
+                        </constraints>
                     </view>
                     <connections>
-                        <outlet property="countryCodeTextField" destination="FAX-UP-Jfb" id="BIT-uN-ybA"/>
-                        <outlet property="phoneNumberTextField" destination="r2E-Fq-sN6" id="09B-Mq-rGU"/>
+                        <outlet property="phoneNumberTextField" destination="EVo-Ee-8rk" id="Dgo-EJ-FkD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MFj-O5-k01" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="52" y="837"/>
+            <point key="canvasLocation" x="50.724637681159422" y="836.41304347826099"/>
         </scene>
         <!--Phone Authenticate View Controller-->
         <scene sceneID="JGB-D0-bLF">
@@ -466,38 +493,81 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Input Verification Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WEp-mJ-IgN">
-                                <rect key="frame" x="100" y="195" width="175" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3qY-mt-ejf">
-                                <rect key="frame" x="139" y="224" width="97" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3qY-mt-ejf">
+                                <rect key="frame" x="158.66666666666666" y="333" width="97" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="97" id="9su-LH-3yU"/>
+                                    <constraint firstAttribute="height" constant="30" id="bbk-Cy-b24"/>
+                                </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVg-64-EHy">
-                                <rect key="frame" x="115" y="262" width="34" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Back"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify your number" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8EG-OY-pMQ">
+                                <rect key="frame" x="71.666666666666686" y="148" width="271" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="271" id="Jf7-1N-O4c"/>
+                                    <constraint firstAttribute="height" constant="36" id="gpR-Os-j6D"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="30"/>
+                                <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Please enter 4 digit code we just sent you in order to verify your account" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n2g-rJ-Kwq">
+                                <rect key="frame" x="66.666666666666686" y="209" width="281" height="45"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="281" id="20w-gZ-zij"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="281" id="ccR-Uc-FEV"/>
+                                    <constraint firstAttribute="height" constant="45" id="cgX-yn-E0c"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="gQK-ht-jzj"/>
+                                </constraints>
+                                <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" name="PingFangTC-Semibold" family="PingFang TC" pointSize="13"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2g-cE-MXM">
+                                <rect key="frame" x="70.666666666666686" y="430" width="273" height="41"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="273" id="qZZ-Kv-Bf1"/>
+                                    <constraint firstAttribute="height" constant="41" id="vVF-Ai-dCR"/>
+                                </constraints>
+                                <state key="normal" title="Continue">
+                                    <color key="titleColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="confirmButtonTapped:" destination="6wi-dA-koT" eventType="touchUpInside" id="qAb-Xn-xEw"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVg-64-EHy">
+                                <rect key="frame" x="153" y="388" width="108" height="17"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="17" id="EuF-XA-fRP"/>
+                                    <constraint firstAttribute="width" constant="108" id="sIo-R7-6aM"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="PingFangTC-Semibold" family="PingFang TC" pointSize="11"/>
+                                <state key="normal" title="Didn't get the code">
+                                    <color key="titleColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
                                 <connections>
                                     <segue destination="W2h-ud-Kx5" kind="show" id="kfa-Iz-l8V"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rd5-f8-55H">
-                                <rect key="frame" x="210" y="262" width="55" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Confirm"/>
-                                <connections>
-                                    <action selector="confirmButtonTapped:" destination="6wi-dA-koT" eventType="touchUpInside" id="lli-4H-3JJ"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="EVg-64-EHy" firstAttribute="centerX" secondItem="pB2-Ko-XuB" secondAttribute="centerX" id="2U7-Vn-qw3"/>
+                            <constraint firstItem="n2g-rJ-Kwq" firstAttribute="top" secondItem="8EG-OY-pMQ" secondAttribute="bottom" constant="25" id="A0q-36-bom"/>
+                            <constraint firstItem="n2g-rJ-Kwq" firstAttribute="centerX" secondItem="pB2-Ko-XuB" secondAttribute="centerX" id="GBm-Nv-USw"/>
+                            <constraint firstItem="f2g-cE-MXM" firstAttribute="centerX" secondItem="pB2-Ko-XuB" secondAttribute="centerX" id="IAD-tF-ZFG"/>
+                            <constraint firstItem="EVg-64-EHy" firstAttribute="top" secondItem="3qY-mt-ejf" secondAttribute="bottom" constant="25" id="Tah-hB-tYk"/>
+                            <constraint firstItem="3qY-mt-ejf" firstAttribute="top" secondItem="n2g-rJ-Kwq" secondAttribute="bottom" constant="79" id="cs8-ns-iGo"/>
+                            <constraint firstItem="8EG-OY-pMQ" firstAttribute="centerX" secondItem="pB2-Ko-XuB" secondAttribute="centerX" id="oLL-uk-IEl"/>
+                            <constraint firstItem="8EG-OY-pMQ" firstAttribute="top" secondItem="8Qn-Wx-2Sl" secondAttribute="bottom" constant="128" id="pYI-rL-y0I"/>
+                            <constraint firstItem="f2g-cE-MXM" firstAttribute="top" secondItem="EVg-64-EHy" secondAttribute="bottom" constant="25" id="sWg-PU-u8E"/>
+                            <constraint firstItem="3qY-mt-ejf" firstAttribute="centerX" secondItem="pB2-Ko-XuB" secondAttribute="centerX" id="yRF-26-fZH"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="verificationCodeTextField" destination="3qY-mt-ejf" id="yPg-af-8KQ"/>
@@ -506,6 +576,54 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aaI-LV-BEi" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="825" y="836"/>
+        </scene>
+        <!--ProfileGNBViewController-->
+        <scene sceneID="GIX-wn-jQD">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pP3-S2-RPl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewController storyboardIdentifier="ProfileGNBViewController" title="ProfileGNBViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="IvN-LX-e3l" customClass="ProfileGNBViewController" customModule="NewDawn" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="iaC-Dy-Cff"/>
+                        <viewControllerLayoutGuide type="bottom" id="yH2-Zt-D3t"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" restorationIdentifier="ProfileGNBViewController" id="ZKy-hO-AYx">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Let us know more  about you" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W2s-sC-0PV">
+                                <rect key="frame" x="72" y="144" width="270" height="80"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="Pog-x6-XXW"/>
+                                    <constraint firstAttribute="width" constant="270" id="myI-JZ-gFS"/>
+                                </constraints>
+                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="30"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Fill out the details so you can have a better match" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zM-7y-F79">
+                                <rect key="frame" x="70.666666666666686" y="239" width="273" height="48"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="273" id="k4N-OX-gOH"/>
+                                    <constraint firstAttribute="height" constant="48" id="xHH-4r-NPI"/>
+                                </constraints>
+                                <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="4zM-7y-F79" firstAttribute="top" secondItem="W2s-sC-0PV" secondAttribute="bottom" constant="15" id="77w-PY-MOi"/>
+                            <constraint firstItem="W2s-sC-0PV" firstAttribute="top" secondItem="iaC-Dy-Cff" secondAttribute="bottom" constant="124" id="JaB-dJ-uh6"/>
+                            <constraint firstItem="4zM-7y-F79" firstAttribute="centerX" secondItem="ZKy-hO-AYx" secondAttribute="centerX" id="YJf-t1-8oW"/>
+                            <constraint firstItem="W2s-sC-0PV" firstAttribute="centerX" secondItem="ZKy-hO-AYx" secondAttribute="centerX" id="dKg-bJ-ea8"/>
+                        </constraints>
+                    </view>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="1576.8115942028987" y="835.59782608695662"/>
         </scene>
     </scenes>
 </document>

--- a/NewDawn/NewDawn/PhoneAuthenticateViewController.swift
+++ b/NewDawn/NewDawn/PhoneAuthenticateViewController.swift
@@ -80,7 +80,18 @@ class PhoneAuthenticateViewController: UIViewController {
             self.displayMessage(userMessage: message!)
             return
         }
-        self.displayMessage(userMessage: message!)
+        
+        // Store phone number locally
+        localStoreKeyValue(key: "phoneNumber", value: userPhoneNumber)
+        
+        // Phone verification success. Go to main registration page
+        // Go to profile gender/name/birthday fill page
+        DispatchQueue.main.async {
+            let profileGNBPage = self.storyboard?.instantiateViewController(withIdentifier: "ProfileGNBViewController")
+                as! ProfileGNBViewController
+            let appDelegate = UIApplication.shared.delegate
+            appDelegate?.window??.rootViewController = profileGNBPage
+        }
     }
     
     /*

--- a/NewDawn/NewDawn/PhoneVerifyViewController.swift
+++ b/NewDawn/NewDawn/PhoneVerifyViewController.swift
@@ -42,7 +42,7 @@ class PhoneVerifyViewController: UIViewController {
         // Remove activity indicator
         self.removeActivityIndicator(activityIndicator: activityIndicator)
         
-        // Process Request & Remove Activity Indicator
+        // Process Request
         self.processSessionTasks(request: request!, callback: readPhoneVerifyResponse)
         
         // Pass country code and phone number to next view

--- a/NewDawn/NewDawn/PhoneVerifyViewController.swift
+++ b/NewDawn/NewDawn/PhoneVerifyViewController.swift
@@ -9,21 +9,20 @@
 import UIKit
 
 class PhoneVerifyViewController: UIViewController {
-    @IBOutlet weak var countryCodeTextField: UITextField!
-    @IBOutlet weak var phoneNumberTextField: UITextField!
     
+    @IBOutlet weak var phoneNumberTextField: UITextField!
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        phoneNumberTextField.setLeftPaddingPoints(25)
         // Do any additional setup after loading the view.
     }
     
     @IBAction func nextButtonTapped(_ sender: Any) {
-        let countryCode = countryCodeTextField.text
+        // For US only
         let phoneNumber = phoneNumberTextField.text
         
         // Validate Username and Password
-        if (countryCode?.isEmpty)! || (phoneNumber?.isEmpty)!
+        if (phoneNumber?.isEmpty)!
         {
             print("Country Code or Phone Number is Missing")
             return
@@ -53,7 +52,7 @@ class PhoneVerifyViewController: UIViewController {
         // Prepare fields sent to next page
         let authenticateController = segue.destination as! PhoneAuthenticateViewController
         authenticateController.userPhoneNumber = phoneNumberTextField.text!
-        authenticateController.userCountryCode = countryCodeTextField.text!
+        authenticateController.userCountryCode = "1"
     }
     
     // Create Phoen Verify request according to API spec
@@ -65,7 +64,7 @@ class PhoneVerifyViewController: UIViewController {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         let postString = [
             "phone_number": phoneNumberTextField.text!,
-            "country_code": countryCodeTextField.text!
+            "country_code": "1"
             ] as [String: String]
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: postString, options: .prettyPrinted)
@@ -85,7 +84,7 @@ class PhoneVerifyViewController: UIViewController {
             return
         }
     }
-    
+
     /*
     // MARK: - Navigation
 
@@ -96,4 +95,17 @@ class PhoneVerifyViewController: UIViewController {
     }
     */
 
+}
+
+extension UITextField {
+    func setLeftPaddingPoints(_ amount:CGFloat){
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+    func setRightPaddingPoints(_ amount:CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.rightView = paddingView
+        self.rightViewMode = .always
+    }
 }

--- a/NewDawn/NewDawn/ProfileGNBViewController.swift
+++ b/NewDawn/NewDawn/ProfileGNBViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ProfileGNBViewController.swift
+//  NewDawn
+//
+//  Created by 汤子毅 on 2018/12/21.
+//  Copyright © 2018 New Dawn. All rights reserved.
+//
+
+import UIKit
+
+class ProfileGNBViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/NewDawn/NewDawn/UserInfoModel.xcdatamodeld/UserInfoModel.xcdatamodel/contents
+++ b/NewDawn/NewDawn/UserInfoModel.xcdatamodeld/UserInfoModel.xcdatamodel/contents
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18C54" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
-        <attribute name="collegeName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="companyName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="homeTown" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="jobTitle" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="smoke" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
-    </entity>
-    <elements>
-        <element name="User" positionX="-63" positionY="-18" width="128" height="150"/>
-    </elements>
+    <elements/>
 </model>

--- a/NewDawn/NewDawn/UserInfoModel.xcdatamodeld/UserInfoModel.xcdatamodel/contents
+++ b/NewDawn/NewDawn/UserInfoModel.xcdatamodeld/UserInfoModel.xcdatamodel/contents
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18C54" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
+        <attribute name="collegeName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="companyName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="homeTown" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="jobTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="smoke" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="User" positionX="-63" positionY="-18" width="128" height="150"/>
+    </elements>
+</model>

--- a/NewDawn/NewDawn/ViewController.swift
+++ b/NewDawn/NewDawn/ViewController.swift
@@ -107,6 +107,19 @@ extension UIViewController {
         // Concatenate according to TastyPie requirement
         return "ApiKey \(String(describing: username)):\(String(describing: accessToken))"
     }
+    
+    func localStoreKeyValue(key: String, value: String) -> Void {
+        let userDefaults = UserDefaults.standard
+        userDefaults.set(value, forKey: key)
+        userDefaults.synchronize()
+    }
+    
+    func localReadKeyValue(key: String) -> String {
+        if let value: String = UserDefaults.standard.object(forKey: key) as! String? {
+            return value
+        }
+        return "No Value Founded"
+    }
 }
 
 


### PR DESCRIPTION
Add some UI to the original phone verification page. Complete the whole experience.
Leave international phone number and verification number UI as is since @tianchuxie is working on that.

![screen shot 2018-12-21 at 7 27 59 pm](https://user-images.githubusercontent.com/8229754/50369411-31634000-0563-11e9-9b75-c3f86b7e762a.png)
![screen shot 2018-12-21 at 7 28 05 pm](https://user-images.githubusercontent.com/8229754/50369412-31634000-0563-11e9-98b1-9a6513257aed.png)
![screen shot 2018-12-21 at 8 55 58 pm](https://user-images.githubusercontent.com/8229754/50369413-31634000-0563-11e9-9b59-9bec49a4342e.png)
