### PR TITLE
Centralize main page fetch/refresh logic to ending page

### DIFF
--- a/NewDawn/NewDawn/MainPageViewController.swift
+++ b/NewDawn/NewDawn/MainPageViewController.swift
@@ -16,21 +16,20 @@ class MainPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if TimerUtil.isOutdated(){
-            UserProfileBuilder.fetchAndStoreUserProfiles()
-        }
         var user_profiles:[UserProfile] = UserProfileBuilder.getUserProfileListFromLocalStorage()
-        if ProfileIndexUtil.loadProfileIndex() >= user_profiles.count {
-            // TODO: When the user has seen all profiles, we go back to the first profile.
-            // In the future, we should go to an ending page
-            self.localStoreKeyValue(key: MAIN_PAGE_PROFILE_INDEX, value: 0)
+        if user_profiles.count == 0 || TimerUtil.isOutdated() {
+            // Go to the ending page if no profile is available in local storage or is outdated
+            // The ending page will handle profile fetch and refresh the main page automatically
+            self.performSegue(withIdentifier: "mainPageEnd", sender: nil)
+        } else {
+            // Prepare the current profile view
+            viewModel = MainPageViewModel(userProfile: user_profiles[ProfileIndexUtil.loadProfileIndex()])
+            tableView.dataSource = viewModel
+            tableView.delegate = viewModel
+            tableView.rowHeight = UITableView.automaticDimension
+            tableView.estimatedRowHeight = UITableView.automaticDimension
+            navigationItem.hidesBackButton = true
         }
-        viewModel = MainPageViewModel(userProfile: user_profiles[ProfileIndexUtil.loadProfileIndex()])
-        tableView.dataSource = viewModel
-        tableView.delegate = viewModel
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = UITableView.automaticDimension
-        navigationItem.hidesBackButton = true
     }
 
     @IBAction func skipButtonTapped(_ sender: Any) {

--- a/NewDawn/NewDawn/MainPageViewController/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/MainPageViewController/MainPageEndViewController.swift
@@ -12,8 +12,13 @@ class MainPageEndViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.checkMainPageReload()
         navigationItem.hidesBackButton = true
+
+        // Check if reload is needed and refresh the main page if necessary
+        // TODO: Remove "force = true" since it will always refresh the main page
+        self.checkMainPageReload(true)
+
+        // Check refresh again when user resume the app on ending page
         NotificationCenter.default.addObserver(self, selector: #selector(UIViewController.checkMainPageReload), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     

--- a/NewDawn/NewDawn/Models/UserModels.swift
+++ b/NewDawn/NewDawn/Models/UserModels.swift
@@ -198,14 +198,14 @@ class UserProfileBuilder{
     }
     
     // Usage for user to other users' profiles information from backend
-    static func fetchAndStoreUserProfiles(){
-        // // TODO: get username and api_key from keychain/local storage
+    static func fetchAndStoreUserProfiles(callback: @escaping (NSDictionary) -> Void){
+        // TODO: get username and api_key from keychain/local storage
         let psudo_params = [
-            "username":"duckmoll",
-            "api_key":"f1c085c2ed2196cb029827c80f879a2ef3ce2189"
+            "username":"testadmin",
+            "api_key":"617db2192d5f696b20f6309011a29e1be97aec29"
         ]
         let request = UserProfileBuilder.createGetProfileRequest(input_params: psudo_params)
-        HttpUtil.processSessionTasks(request: request!, callback: fetchAndStoreInLocalStorage)
+        HttpUtil.processSessionTasks(request: request!, callback: callback)
     }
     
     static func parseProfileInfo(profile_data: [String: Any])-> [String: Any]{
@@ -237,7 +237,7 @@ class UserProfileBuilder{
     }
     
     // Store all retrieved users' information to a list of dictionary and into local storage
-    static func fetchAndStoreInLocalStorage(response: NSDictionary)-> Void{
+    static func parseAndStoreInLocalStorage(response: NSDictionary)-> Void{
         var fetched_users = [UserProfile]()
         let profile_responses = response["objects"] as? [[String: Any]]
         for profile in profile_responses!{

--- a/NewDawn/NewDawn/ViewController.swift
+++ b/NewDawn/NewDawn/ViewController.swift
@@ -229,16 +229,22 @@ extension UIViewController {
             width: CGFloat(width), height: CGFloat(height))
     }
     
-    @objc func checkMainPageReload() {
+    // Check if timer is outdated, or force refresh the main page
+    // with newly fetched user profiles. Also update profile index and timer.
+    @objc func checkMainPageReload(_ force: Bool = false) {
         // If the current date is not the latest stored date, refresh the main page entirely
-        if TimerUtil.isOutdated() {
+        if force || TimerUtil.isOutdated() {
             ProfileIndexUtil.refreshProfileIndex()
             TimerUtil.updateDate()
-            DispatchQueue.main.async {
-                let mainPage = self.storyboard?.instantiateViewController(withIdentifier: "MainTabViewController")
-                    as! MainPageTabBarViewController
-                let appDelegate = UIApplication.shared.delegate
-                appDelegate?.window??.rootViewController = mainPage
+            UserProfileBuilder.fetchAndStoreUserProfiles() {
+                (data) in
+                UserProfileBuilder.parseAndStoreInLocalStorage(response: data)
+                DispatchQueue.main.async {
+                    let mainPage = self.storyboard?.instantiateViewController(withIdentifier: "MainTabViewController")
+                        as! MainPageTabBarViewController
+                    let appDelegate = UIApplication.shared.delegate
+                    appDelegate?.window??.rootViewController = mainPage
+                }
             }
         }
     }


### PR DESCRIPTION
If no profile is available in local storage, or if they are outdated, the main page should be directed to the ending page. Ending page will be the only place that handles timer reset and profile index reset , backend profile fetch, and main page refresh when profile fetch is done. 