### PR TITLE
[Media] Adopt media path from S3

### DIFF
--- a/NewDawn/NewDawn/Utils/HttpUtil.swift
+++ b/NewDawn/NewDawn/Utils/HttpUtil.swift
@@ -12,7 +12,7 @@ import UIKit
 
 let imageCache = NSCache<AnyObject, AnyObject>()
 
-let CONNECT_TO_PROD = false
+let CONNECT_TO_PROD = true
 
 extension UIImageView {
     // A helper function to get URL based on prod/test

--- a/NewDawn/NewDawn/Utils/HttpUtil.swift
+++ b/NewDawn/NewDawn/Utils/HttpUtil.swift
@@ -12,7 +12,7 @@ import UIKit
 
 let imageCache = NSCache<AnyObject, AnyObject>()
 
-let CONNECT_TO_PROD = true
+let CONNECT_TO_PROD = false
 
 extension UIImageView {
     // A helper function to get URL based on prod/test
@@ -100,11 +100,9 @@ class HttpUtil{
             final_path = "/" + path
         }
         if isMedia == true {
-            if prod {
-                return URL(string: "http://new-dawn.us-west-2.elasticbeanstalk.com" + final_path)!
-            } else {
-                return URL(string: "http://localhost:8000" + final_path)!
-            }
+            // Media files' path points to an AWS S3 media file server endpoint
+            // It wouldn't hit our application server
+            return URL(string: path)!
         }
         if prod {
             return URL(string: "http://new-dawn.us-west-2.elasticbeanstalk.com/api/v1" + final_path)!


### PR DESCRIPTION
Using S3 will 
1. Simplify our work managing local file system
2. Optimize the speed for image retrieval due to S3's intrinsic caching
3. Extensible for future file serving mechanism like AWS CloudFront.

The URL endpoint from S3 is automatically created when image was uploaded. We can directly use them instead of hitting our application server. See https://github.com/new-dawn/new_dawn_server/pull/138 for details.

Video in slack