### PR TITLE
[Logout] Log out returns to app landing page, removing all info

### DIFF
--- a/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
@@ -1959,7 +1959,7 @@
         <image name="MeTab" width="24" height="24"/>
         <image name="Register_continue_btn" width="255" height="66"/>
         <image name="SendLikeButton" width="101" height="88"/>
-        <image name="SettingContinueButton" width="80" height="80"/>
+        <image name="SettingContinueButton" width="40" height="40"/>
         <image name="SkipButton" width="62" height="62"/>
         <image name="SmokeIcon" width="36" height="24"/>
         <image name="TableCell" width="367" height="306"/>

--- a/NewDawn/NewDawn/Base.lproj/ProfileGNB.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/ProfileGNB.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IvN-LX-e3l">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IvN-LX-e3l">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment version="4352" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -1300,7 +1300,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <segue destination="xSt-Rq-d95" kind="presentation" identifier="after_register" id="DS3-X5-0Y1"/>
+                        <segue destination="xSt-Rq-d95" kind="show" identifier="after_register" id="DS3-X5-0Y1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xQF-Uf-iFU" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1466,8 +1466,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="RegisterPlaceHolder" width="344" height="254"/>
-        <image name="Register_continue_btn" width="510" height="132"/>
+        <image name="RegisterPlaceHolder" width="172" height="127"/>
+        <image name="Register_continue_btn" width="255" height="66"/>
         <image name="SkipButton" width="62" height="62"/>
     </resources>
     <inferredMetricsTieBreakers>

--- a/NewDawn/NewDawn/Utils/LocalStorageUtil.swift
+++ b/NewDawn/NewDawn/Utils/LocalStorageUtil.swift
@@ -42,6 +42,11 @@ class LocalStorageUtil {
     static func localRemoveKey(key: String) {
         UserDefaults.standard.removeObject(forKey: key)
     }
+    
+    static func localRemoveAll() {
+        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+        UserDefaults.standard.synchronize()
+    }
 }
 
 class LoginUserUtil {
@@ -70,9 +75,18 @@ class LoginUserUtil {
         return KeychainWrapper.standard.hasValue(forKey: LoginUserUtil.USER_ID) && KeychainWrapper.standard.hasValue(forKey: LoginUserUtil.ACCESS_TOKEN)
     }
     
-    static func logout() -> Bool {
-        LocalStorageUtil.localRemoveKey(key: LoginUserUtil.LOGIN_USER_PROFILE)
-        return KeychainWrapper.standard.removeAllKeys()
+    static func logout() -> Void {
+        _ = KeychainWrapper.standard.removeAllKeys()
+        LocalStorageUtil.localRemoveAll()
+        // Take user to the landing page
+        let landingStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
+        // Go to profile page
+        DispatchQueue.main.async {
+            let landingPage = landingStoryboard.instantiateViewController(withIdentifier: "AppLandingViewController")
+                as! AppLandingViewController
+            let appDelegate = UIApplication.shared.delegate
+            appDelegate?.window??.rootViewController = landingPage
+        }
     }
 
     static func fetchUserProfile(user_id: Int, accessToken: String, callback: @escaping (UserProfile?, String?) -> Void) -> Void {

--- a/NewDawn/NewDawn/ViewControllers/AppLandingViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/AppLandingViewController.swift
@@ -14,7 +14,7 @@ class AppLandingViewController: UIViewController {
         super.viewDidLoad()
         // Override point for customization after application launch.
         if LoginUserUtil.isLogin() {
-            LoginUserUtil.fetchLoginUserProfile() {
+            LoginUserUtil.fetchLoginUserProfile(readLocal: false) {
                 user_profile, error in
                 if error != nil {
                     self.displayMessage(userMessage: "Error: Fetch Login User Profile Failed for user id \(String(describing: LoginUserUtil.getLoginUserId())): \(error!). This can happen if you don't have accessToken stored locally")
@@ -30,9 +30,6 @@ class AppLandingViewController: UIViewController {
                     _ = LoginUserUtil.logout()
                 }
             }
-        } else {
-            // Even if the user wasn't login, we clean up the credential for safety
-            _ = LoginUserUtil.logout()
         }
     }
     

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
@@ -35,12 +35,12 @@ class MainPageEndViewController: UIViewController {
             self.checkMainPageReload(true)
         }
         confirmAction.setValue(UIColor.black, forKey: "titleTextColor")
-        let cancelAction = UIAlertAction(title: "一会再说", style: .cancel) { (_) in
+        let cancelAction = UIAlertAction(title: "一会再说", style: .default) { (_) in
             self.startTimer()
         }
         cancelAction.setValue(UIColor.black, forKey: "titleTextColor")
-        alertController.addAction(confirmAction)
         alertController.addAction(cancelAction)
+        alertController.addAction(confirmAction)
         self.present(alertController, animated: true, completion: nil)
     }
     

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+let TEST_MAIN_PAGE_REFRESH_TIME = 5
 class MainPageEndViewController: UIViewController {
 
     override func viewDidLoad() {
@@ -16,13 +17,32 @@ class MainPageEndViewController: UIViewController {
 
         // Check if reload is needed and refresh the main page if necessary
         // TODO: Remove "force = true" since it will always refresh the main page
-        self.checkMainPageReload(true)
-
+        
+        startTimer()
         // Check refresh again when user resume the app on ending page
         NotificationCenter.default.addObserver(self, selector: #selector(UIViewController.checkMainPageReload), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
-
+    func startTimer() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(TEST_MAIN_PAGE_REFRESH_TIME), execute: {
+            self.notifyNewCandidates()
+        })
+    }
+    
+    func notifyNewCandidates(){
+        let alertController = UIAlertController(title: nil, message: "新的推荐已经产生", preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "快去看看", style: .default) { (_) in
+            self.checkMainPageReload(true)
+        }
+        confirmAction.setValue(UIColor.black, forKey: "titleTextColor")
+        let cancelAction = UIAlertAction(title: "一会再说", style: .cancel) { (_) in
+            self.startTimer()
+        }
+        cancelAction.setValue(UIColor.black, forKey: "titleTextColor")
+        alertController.addAction(confirmAction)
+        alertController.addAction(cancelAction)
+        self.present(alertController, animated: true, completion: nil)
+    }
     
 
     /*

--- a/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/ProfileSettingViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/ProfileSettingViewController.swift
@@ -137,17 +137,7 @@ class ProfileSettingViewController: UIViewController, UITableViewDelegate, UITab
         let alertController = UIAlertController(title: nil, message: "Are you sure you want to log out?", preferredStyle: .alert)
         alertController.setValue(NSAttributedString(string: alertController.message!, attributes: [NSAttributedString.Key.font : UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.semibold), NSAttributedString.Key.foregroundColor : UIColor.black]), forKey: "attributedMessage")
         let confirmAction = UIAlertAction(title: "Log Out Now      ", style: .default) { (_) in
-            if LoginUserUtil.logout() {
-                // Take user to login page
-                let loginStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
-                // Go to profile page
-                DispatchQueue.main.async {
-                    let loginPage = loginStoryboard.instantiateViewController(withIdentifier: "PhoneVerifyViewController")
-                        as! PhoneVerifyViewController
-                    let appDelegate = UIApplication.shared.delegate
-                    appDelegate?.window??.rootViewController = loginPage
-                }
-            }
+            _ = LoginUserUtil.logout()
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { (_) in}
         cancelAction.setValue(UIColor.black, forKey: "titleTextColor")

--- a/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/SettingPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/SettingPageViewController.swift
@@ -42,6 +42,8 @@ class SettingPageViewController: UIViewController {
                 LoginUserUtil.logout()
                 return
             }
+            // TODO: Have a helper function to check both login
+            // user id and access token matching status
             if user_profile == nil && LoginUserUtil.getLoginUserId() != 1 {
                 self.displayMessage(userMessage: "Error: User profile doesn't exist. This might mean that your profile has been deleted from database: \(error!)")
                 LoginUserUtil.logout()

--- a/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/SettingPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/SettingPageViewControllers/SettingPageViewController.swift
@@ -38,9 +38,13 @@ class SettingPageViewController: UIViewController {
         LoginUserUtil.fetchLoginUserProfile(readLocal: false) {
             user_profile, error in
             if error != nil {
-                DispatchQueue.main.async {
-                    self.displayMessage(userMessage: "Error: Fetch Login User Profile Failed: \(error!)")
-                }
+                self.displayMessage(userMessage: "Error: Fetch Login User Profile Failed: \(error!)")
+                LoginUserUtil.logout()
+                return
+            }
+            if user_profile == nil && LoginUserUtil.getLoginUserId() != 1 {
+                self.displayMessage(userMessage: "Error: User profile doesn't exist. This might mean that your profile has been deleted from database: \(error!)")
+                LoginUserUtil.logout()
                 return
             }
             if user_profile != nil {


### PR DESCRIPTION
Make sure that logout is robust enough.
Also make sure that if the user goes to the setting page, it will automatically logout if the profile doesn't exist

Also add a temporary timer to the main page ending page to make the user waiting for new candidates. This is to make sure that if a user always has NO candidate, it won't infinitely send request to the server