### PR TITLE
[easy] Fix last message display on Chat page

### DIFF
--- a/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
@@ -48,7 +48,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="You guys have been matched" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f3p-Hx-CK5">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="恭喜你们匹配成功，请点击进入聊天" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f3p-Hx-CK5">
                                                     <rect key="frame" x="121" y="56" width="231" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="PingFangTC-Semibold" family="PingFang TC" pointSize="12"/>

--- a/NewDawn/NewDawn/ViewControllers/ChatPageViewControllers/ChatPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/ChatPageViewControllers/ChatPageViewController.swift
@@ -16,6 +16,7 @@ let MESSAGES = "messages"
 let VIEWED_MESSAGES = "viewed_messages"
 let MATCHED_USER_ID = "matched_user_id"
 let MESSAGE_ID = "message_id"
+let DEFAULT_MESSAGE = "恭喜你们匹配成功，请点击进入聊天"
 
 class ChatPageViewController: UIViewController {
     
@@ -131,7 +132,12 @@ class ChatPageTableViewModel: NSObject, UITableViewDelegate, UITableViewDataSour
                             cell.chatNotifImageView.isHidden = false
                         }
                     }
+                } else {
+                    cell.lastMessageText?.text = DEFAULT_MESSAGE
+                    cell.chatNotifImageView.isHidden = false
                 }
+            } else {
+                
             }
         }
         return cell

--- a/NewDawn/NewDawn/ViewControllers/ChatPageViewControllers/ChatPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/ChatPageViewControllers/ChatPageViewController.swift
@@ -136,8 +136,6 @@ class ChatPageTableViewModel: NSObject, UITableViewDelegate, UITableViewDataSour
                     cell.lastMessageText?.text = DEFAULT_MESSAGE
                     cell.chatNotifImageView.isHidden = false
                 }
-            } else {
-                
             }
         }
         return cell


### PR DESCRIPTION
<img width="424" alt="Screen Shot 2019-07-08 at 9 06 01 PM" src="https://user-images.githubusercontent.com/8229754/60852087-37013a00-a1c4-11e9-8da0-15979998432c.png">

The last message no longer mixes up