### PR TITLE
[Main page] Main Page Timer Loading Refactor

### DIFF
--- a/NewDawn/NewDawn.xcodeproj/project.pbxproj
+++ b/NewDawn/NewDawn.xcodeproj/project.pbxproj
@@ -524,7 +524,6 @@
 					24F6581621B31C1400DB2547 = {
 						CreatedOnToolsVersion = 8.1;
 						LastSwiftMigration = 1010;
-						ProvisioningStyle = Automatic;
 						TestTargetID = 24F657F721B31C1300DB2547;
 					};
 				};
@@ -936,7 +935,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = NewDawn/NewDawn.entitlements;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5M2WD33Q6U;
 				INFOPLIST_FILE = NewDawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -958,7 +957,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = NewDawn/NewDawn.entitlements;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5M2WD33Q6U;
 				INFOPLIST_FILE = NewDawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1018,6 +1017,9 @@
 			baseConfigurationReference = 5FCA5609F5DFD32BE2FFF302 /* Pods-NewDawnUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawnUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1026,6 +1028,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.new-dawn.NewDawnUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = NewDawn;
@@ -1037,6 +1041,9 @@
 			baseConfigurationReference = EAA2FE4297433EA944BC186B /* Pods-NewDawnUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawnUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1045,6 +1052,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.new-dawn.NewDawnUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = NewDawn;

--- a/NewDawn/NewDawn.xcodeproj/project.pbxproj
+++ b/NewDawn/NewDawn.xcodeproj/project.pbxproj
@@ -935,7 +935,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = NewDawn/NewDawn.entitlements;
-				DEVELOPMENT_TEAM = 5M2WD33Q6U;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -957,7 +957,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = NewDawn/NewDawn.entitlements;
-				DEVELOPMENT_TEAM = 5M2WD33Q6U;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1017,6 +1017,8 @@
 			baseConfigurationReference = 5FCA5609F5DFD32BE2FFF302 /* Pods-NewDawnUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawnUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1039,6 +1041,8 @@
 			baseConfigurationReference = EAA2FE4297433EA944BC186B /* Pods-NewDawnUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NewDawnUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
+++ b/NewDawn/NewDawn/Base.lproj/MainPage.storyboard
@@ -2073,7 +2073,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="目前推送已经浏览完了 我们明日会再次 为您推送适合的人选" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xH9-Ne-pni">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="目前推送已经浏览完了 我们会在以下时间 再次为您推送适合的人选" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xH9-Ne-pni">
                                 <rect key="frame" x="32" y="392" width="310" height="90"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2084,10 +2084,20 @@
                                 <rect key="frame" x="76" y="139" width="222" height="222"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VBh-cX-Mo9">
+                                <rect key="frame" x="83" y="490" width="209" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.98431372549999996" green="0.97647058819999999" blue="0.96470588239999999" alpha="1" colorSpace="calibratedRGB"/>
                         <viewLayoutGuide key="safeArea" id="wUl-5W-KJG"/>
                     </view>
+                    <connections>
+                        <outlet property="timer" destination="VBh-cX-Mo9" id="bZE-7G-E8l"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5XU-2e-ajw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -2096,7 +2106,7 @@
         <!--Main Page Match View Controller-->
         <scene sceneID="35Z-IR-CMf">
             <objects>
-                <viewController storyboardIdentifier="MainPageMatchViewController" id="FbV-Da-f0i" customClass="MainPageMatchViewController" customModule="NewDawn" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainPageMatchViewController" modalTransitionStyle="crossDissolve" modalPresentationStyle="overCurrentContext" id="FbV-Da-f0i" customClass="MainPageMatchViewController" customModule="NewDawn" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="10H-ge-FPA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NewDawn/NewDawn/Utils/TimerUtil.swift
+++ b/NewDawn/NewDawn/Utils/TimerUtil.swift
@@ -36,7 +36,7 @@ struct DateTuple: Codable, Comparable {
 }
 
 class TimerUtil {
-    static let REFRESH_TIME_IN_SEC = 20
+    static let REFRESH_TIME_IN_SEC = 60
     
     static func buildDateTuple(date: DateComponents) -> DateTuple {
         return DateTuple(

--- a/NewDawn/NewDawn/Utils/TimerUtil.swift
+++ b/NewDawn/NewDawn/Utils/TimerUtil.swift
@@ -14,26 +14,40 @@ struct DateTuple: Codable, Comparable {
     var year: Int
     var month: Int
     var day: Int
-    init(year: Int, month: Int, day: Int) {
+    var hour: Int
+    var minute: Int
+    var second: Int
+    init(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) {
         self.year = year
         self.month = month
         self.day = day
+        self.hour = hour
+        self.minute = minute
+        self.second = second
     }
     
     static func == (lhs: DateTuple, rhs: DateTuple) -> Bool {
-        return lhs.year == rhs.year &&
-            lhs.month == rhs.month &&
-            lhs.day == rhs.day
+        return [lhs.year, lhs.month, lhs.day, lhs.hour, lhs.minute, lhs.second].elementsEqual([rhs.year, rhs.month, rhs.day, rhs.hour, rhs.minute, rhs.second])
     }
     
     static func < (lhs: DateTuple, rhs: DateTuple) -> Bool {
-        return lhs.year < rhs.year ||
-            (lhs.year == rhs.year && lhs.month < rhs.month) ||
-            (lhs.year == rhs.year && lhs.month == rhs.month && lhs.day < rhs.day)
+        return [lhs.year, lhs.month, lhs.day, lhs.hour, lhs.minute, lhs.second].lexicographicallyPrecedes([rhs.year, rhs.month, rhs.day, rhs.hour, rhs.minute, rhs.second])
     }
 }
 
 class TimerUtil {
+    static let REFRESH_TIME_IN_SEC = 10
+    
+    static func buildDateTuple(date: DateComponents) -> DateTuple {
+        return DateTuple(
+            year: date.year!,
+            month: date.month!,
+            day: date.day!,
+            hour: date.hour!,
+            minute: date.minute!,
+            second: date.second!
+        )
+    }
     // A helper function to get current date
     static func getCurrentDate() -> DateTuple {
         let currentDateTime = Date()
@@ -48,33 +62,48 @@ class TimerUtil {
         ]
         // get the components
         let dateTimeComponents = userCalendar.dateComponents(requestedComponents, from: currentDateTime)
-        return DateTuple(year: dateTimeComponents.year!, month: dateTimeComponents.month!, day: dateTimeComponents.day!)
+        return buildDateTuple(date: dateTimeComponents)
+    }
+    // A helper function to get current date
+    static func getRefreshDate() -> DateTuple {
+        let currentDateTime = Date()
+        let userCalendar = Calendar.current
+        let refreshDate = Calendar.current.date(byAdding: .second, value: REFRESH_TIME_IN_SEC, to: currentDateTime)
+        let requestedComponents: Set<Calendar.Component> = [
+            .year,
+            .month,
+            .day,
+            .hour,
+            .minute,
+            .second
+        ]
+        // get the components
+        let dateTimeComponents = userCalendar.dateComponents(requestedComponents, from: refreshDate ?? currentDateTime)
+        return buildDateTuple(date: dateTimeComponents)
     }
     
     // A helper function to store the latest date
-    static func setStoredDate(date: DateTuple) -> Void {
-        LocalStorageUtil.localStoreKeyValueStruct(key: STORED_DATE, value: date)
+    static func storeRefreshDate() -> Void {
+        LocalStorageUtil.localStoreKeyValueStruct(key: STORED_DATE, value: getRefreshDate())
     }
     
     // A helper function to get the latest date
-    static func readStoredDate() -> DateTuple {
+    static func readRefreshDate() -> DateTuple {
         if let stored_date: DateTuple = LocalStorageUtil.localReadKeyValueStruct(key: STORED_DATE) {
             return stored_date
         } else {
-            let currentDate = getCurrentDate()
-            setStoredDate(date: currentDate)
-            return currentDate
+            storeRefreshDate()
+            return getRefreshDate()
         }
     }
     
     // A helper function to check if current date surpasses the latest date
-    static func isOutdated(always: Bool = false) -> Bool {
-        // TODO: Make always default to false
-        return always || getCurrentDate() > readStoredDate()
-    }
-    
-    // A helper function to update the stored data
-    static func updateDate() -> Void {
-        setStoredDate(date: getCurrentDate())
+    static func checkIfOutdatedAndRefresh() -> Bool {
+        if getCurrentDate() > readRefreshDate() {
+            storeRefreshDate()
+            return true
+        } else {
+            return false
+        }
     }
 }

--- a/NewDawn/NewDawn/Utils/TimerUtil.swift
+++ b/NewDawn/NewDawn/Utils/TimerUtil.swift
@@ -36,7 +36,7 @@ struct DateTuple: Codable, Comparable {
 }
 
 class TimerUtil {
-    static let REFRESH_TIME_IN_SEC = 10
+    static let REFRESH_TIME_IN_SEC = 20
     
     static func buildDateTuple(date: DateComponents) -> DateTuple {
         return DateTuple(

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
@@ -17,7 +17,7 @@ class MainPageEndViewController: UIViewController {
         if TimerUtil.checkIfOutdatedAndRefresh() {
             // Wait for user profile to be available
             let mainPageStoryboard:UIStoryboard = UIStoryboard(name: "MainPage", bundle: nil)
-            let homePage = mainPageStoryboard.instantiateViewController(withIdentifier: "MainTabViewController") as! MainPageTabBarViewController
+            let homePage = mainPageStoryboard.instantiateViewController(withIdentifier: "MainPageViewController") as! MainPageTabBarViewController
             let appDelegate = UIApplication.shared.delegate
             appDelegate?.window??.rootViewController = homePage
         }

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
@@ -10,40 +10,22 @@ import UIKit
 
 let TEST_MAIN_PAGE_REFRESH_TIME = 5
 class MainPageEndViewController: UIViewController {
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationItem.hidesBackButton = true
+        if TimerUtil.checkIfOutdatedAndRefresh() {
+            // Wait for user profile to be available
+            let mainPageStoryboard:UIStoryboard = UIStoryboard(name: "MainPage", bundle: nil)
+            let homePage = mainPageStoryboard.instantiateViewController(withIdentifier: "MainTabViewController") as! MainPageTabBarViewController
+            let appDelegate = UIApplication.shared.delegate
+            appDelegate?.window??.rootViewController = homePage
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.hidesBackButton = true
-
-        // Check if reload is needed and refresh the main page if necessary
-        // TODO: Remove "force = true" since it will always refresh the main page
-        
-        startTimer()
-        // Check refresh again when user resume the app on ending page
-        NotificationCenter.default.addObserver(self, selector: #selector(UIViewController.checkMainPageReload), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
-    
-    func startTimer() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(TEST_MAIN_PAGE_REFRESH_TIME), execute: {
-            self.notifyNewCandidates()
-        })
-    }
-    
-    func notifyNewCandidates(){
-        let alertController = UIAlertController(title: nil, message: "新的推荐已经产生", preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "快去看看", style: .default) { (_) in
-            self.checkMainPageReload(true)
-        }
-        confirmAction.setValue(UIColor.black, forKey: "titleTextColor")
-        let cancelAction = UIAlertAction(title: "一会再说", style: .default) { (_) in
-            self.startTimer()
-        }
-        cancelAction.setValue(UIColor.black, forKey: "titleTextColor")
-        alertController.addAction(cancelAction)
-        alertController.addAction(confirmAction)
-        self.present(alertController, animated: true, completion: nil)
-    }
-    
 
     /*
     // MARK: - Navigation

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageEndViewController.swift
@@ -8,16 +8,18 @@
 
 import UIKit
 
-let TEST_MAIN_PAGE_REFRESH_TIME = 5
 class MainPageEndViewController: UIViewController {
     
+    @IBOutlet weak var timer: UILabel!
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationItem.hidesBackButton = true
+        let nextDate = TimerUtil.readRefreshDate()
+        timer.text = "\(nextDate.month)/\(nextDate.day) \(nextDate.hour):\(nextDate.minute):\(nextDate.second)"
         if TimerUtil.checkIfOutdatedAndRefresh() {
             // Wait for user profile to be available
             let mainPageStoryboard:UIStoryboard = UIStoryboard(name: "MainPage", bundle: nil)
-            let homePage = mainPageStoryboard.instantiateViewController(withIdentifier: "MainPageViewController") as! MainPageTabBarViewController
+            let homePage = mainPageStoryboard.instantiateViewController(withIdentifier: "MainTabViewController") as! MainPageTabBarViewController
             let appDelegate = UIApplication.shared.delegate
             appDelegate?.window??.rootViewController = homePage
         }

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageViewController.swift
@@ -78,7 +78,6 @@ class MainPageViewController: UIViewController {
             DispatchQueue.main.async {
                 self.user_profiles = profiles
                 self.profileIndex = -1 // Next round will update to 0
-                self.refreshTabBarCounterBadge()
                 self.performSegueToNextProfile(self)
             }
         }

--- a/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/MainPageViewControllers/MainPageViewController.swift
@@ -47,13 +47,13 @@ class MainPageViewController: UIViewController {
                 // Start new round
                 self.user_profiles = profiles
                 self.profileIndex = -1
-                self.refreshTabBarCounterBadge(self.user_profiles)
+                self.refreshTabBarCounterBadge()
                 DispatchQueue.main.async {
                     self.performSegue(withIdentifier: "mainPageSelf", sender: nil)
                 }
             }
         } else {
-            if self.user_profiles == nil {
+            if self.user_profiles == nil || self.user_profiles.isEmpty == true {
                 // No profiles have been loaded
                 // Get new profiles
                 getNewProfiles() {
@@ -62,7 +62,7 @@ class MainPageViewController: UIViewController {
                     self.user_profiles = profiles
                     self.profileIndex = 0
                     self.setupTableView()
-                    self.refreshTabBarCounterBadge(self.user_profiles)
+                    self.refreshTabBarCounterBadge()
                 }
             } else {
                 self.setupTableView()
@@ -72,6 +72,8 @@ class MainPageViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.navigationItem.hidesBackButton = true
+        NotificationCenter.default.addObserver(self, selector: #selector(self.likeButtonTappedOnPopupModal), name: NSNotification.Name(rawValue: "likeButtonTappedOnPopupModal"), object: nil)
         LoginUserUtil.fetchLoginUserProfile() {
             my_profile, error in
             if error != nil || my_profile == nil {
@@ -84,10 +86,10 @@ class MainPageViewController: UIViewController {
             self.checkRefreshRecommendation()
         }
     }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-            NotificationCenter.default.addObserver(self, selector: #selector(self.likeButtonTappedOnPopupModal), name: NSNotification.Name(rawValue: "likeButtonTappedOnPopupModal"), object: nil)
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -107,8 +109,6 @@ class MainPageViewController: UIViewController {
     }
     
     func performSegueToNextProfile(_ sender: Any) {
-        NotificationCenter.default.removeObserver(self)
-        refreshTabBarCounterBadge(user_profiles)
         // This is the last profile. The next one is empty.
         if profileIndex + 1 >= user_profiles.count {
             self.performSegue(withIdentifier: "mainPageEnd", sender: nil)
@@ -152,9 +152,9 @@ class MainPageViewController: UIViewController {
         }
     }
 
-    func refreshTabBarCounterBadge(_ profiles: [UserProfile]) {
+    func refreshTabBarCounterBadge() {
         DispatchQueue.main.async {
-            self.tabBarController?.tabBar.items?.first?.badgeValue = "\(String(ProfileIndexUtil.numOfRemainedProfile(profiles: self.user_profiles)))"
+            self.tabBarController?.tabBar.items?.first?.badgeValue = "\(String(self.user_profiles.count - self.profileIndex - 1))"
         }
     }
     
@@ -194,7 +194,6 @@ class MainPageViewController: UIViewController {
             self.tableView.rowHeight = UITableView.automaticDimension
             self.tableView.estimatedRowHeight = UITableView.automaticDimension
             self.tableView.backgroundColor = UIColor.init(red: 251, green: 249, blue: 246, alpha: 1)
-            self.navigationItem.hidesBackButton = true
         }
     }
 }

--- a/NewDawn/NewDawn/ViewControllers/ViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/ViewController.swift
@@ -231,39 +231,6 @@ extension UIViewController {
     func getReviewStatus() -> Dictionary<String, String> {
         return ["review_status__gte": String(UserReviewStatus.NORMAL.rawValue)]
     }
-    
-    // Check if timer is outdated, or force refresh the main page
-    // with newly fetched user profiles. Also update profile index and timer.
-    @objc func checkMainPageReload(_ force: Bool = false) {
-        // If the current date is not the latest stored date, refresh the main page entirely
-        if force || TimerUtil.isOutdated() {
-            ProfileIndexUtil.refreshProfileIndex()
-            TimerUtil.updateDate()
-            if LoginUserUtil.getLoginUserId() == nil {
-                displayMessage(userMessage: "Error: Cannot find login user id from keychain")
-                return
-            }
-            var params = ["viewer_id": String(LoginUserUtil.getLoginUserId()!)]
-            params += getPref()
-            params += getReviewStatus()
-            UserProfileBuilder.fetchUserProfiles(params: params) {
-                (data, error) in
-                if error != nil {
-                    DispatchQueue.main.async {
-                        self.displayMessage(userMessage: "Error: Fetch Login User Profile Failed: \(error!)")
-                    }
-                    return
-                }
-                UserProfileBuilder.parseAndStoreInLocalStorage(response: data)
-                DispatchQueue.main.async {
-                    let mainPage = self.storyboard?.instantiateViewController(withIdentifier: "MainTabViewController")
-                        as! MainPageTabBarViewController
-                    let appDelegate = UIApplication.shared.delegate
-                    appDelegate?.window??.rootViewController = mainPage
-                }
-            }
-        }
-    }
 }
 
 extension UITextField {


### PR DESCRIPTION
Previously. Main page loading only happens at the end of the profile, and the timer is not real (force refresh). This makes the timer loading real and the view can get refreshed whenever timer expires.
<img width="421" alt="Screen Shot 2019-07-13 at 12 27 17 PM" src="https://user-images.githubusercontent.com/8229754/61174094-9915c280-a569-11e9-9b60-7e3416724d91.png">

The timer is stored in local storage. Initially the time S we store is S = T + X where T is the current time and X is the refresh window (like 1 day). Then everytime the user load the main page, we will check if the current time T2 > S. If so, the main page will be refreshed, and we will let S = T2 + X; otherwise, we will not change the timer and the main page will read from previous state (same profile set at certain location)

At the end of main page, there will be a "next refreshing time" text which will show S explicitly to users.