### PR TITLE
Temporary unhide the login button

### DIFF
--- a/NewDawn/NewDawn/ViewControllers/AppLandingViewController.swift
+++ b/NewDawn/NewDawn/ViewControllers/AppLandingViewController.swift
@@ -41,7 +41,7 @@ class AppLandingViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        launchButton.isHidden = true
+        launchButton.isHidden = false
     }
     
     func goToMainPage() -> Void {


### PR DESCRIPTION
The login button is unable to be un-hide for some reason I don't know. So now I'm temporarily set it to false.

Verify that the button can now show up